### PR TITLE
feat(db): add database introspection support (#64)

### DIFF
--- a/__tests__/introspection.test.js
+++ b/__tests__/introspection.test.js
@@ -1,0 +1,230 @@
+/**
+ * Tests for database introspection query handlers
+ */
+const {
+  handleIntrospectionQuery,
+  handleInformationSchemaTables,
+  handleInformationSchemaColumns,
+  handleInformationSchemaSchemata,
+  handlePgCatalogQuery,
+  handlePgTables,
+  handlePgType,
+  handlePgClass,
+} = require('../src/handlers/queryHandlers');
+
+const { DATA_TYPES } = require('../src/protocol/constants');
+
+// Mock connection state for testing
+const mockConnState = {
+  parameters: new Map([
+    ['user', 'testuser'],
+    ['database', 'testdb'],
+  ]),
+  transactionStatus: 'I',
+};
+
+describe('Database Introspection Queries', () => {
+  describe('Main Introspection Handler', () => {
+    test('should route information_schema.tables queries correctly', () => {
+      const query = 'SELECT * FROM information_schema.tables';
+      const result = handleIntrospectionQuery(query, mockConnState);
+      
+      expect(result.command).toBe('SELECT');
+      expect(result.columns).toBeDefined();
+      expect(result.rows).toBeDefined();
+      expect(result.rowCount).toBeGreaterThan(0);
+    });
+
+    test('should route information_schema.columns queries correctly', () => {
+      const query = 'SELECT * FROM information_schema.columns';
+      const result = handleIntrospectionQuery(query, mockConnState);
+      
+      expect(result.command).toBe('SELECT');
+      expect(result.columns).toBeDefined();
+      expect(result.rows).toBeDefined();
+      expect(result.rowCount).toBeGreaterThan(0);
+    });
+
+    test('should route pg_catalog queries correctly', () => {
+      const query = 'SELECT * FROM pg_catalog.pg_tables';
+      const result = handleIntrospectionQuery(query, mockConnState);
+      
+      expect(result.command).toBe('SELECT');
+      expect(result.columns).toBeDefined();
+      expect(result.rows).toBeDefined();
+    });
+
+    test('should handle unknown introspection queries gracefully', () => {
+      const query = 'SELECT * FROM unknown_schema.unknown_table';
+      const result = handleIntrospectionQuery(query, mockConnState);
+      
+      expect(result.command).toBe('SELECT');
+      expect(result.columns[0].name).toBe('note');
+      expect(result.rows[0][0]).toContain('not yet implemented');
+    });
+  });
+
+  describe('Information Schema Tables', () => {
+    test('should return correct table structure for information_schema.tables', () => {
+      const result = handleInformationSchemaTables('', mockConnState);
+      
+      // Check column structure
+      expect(result.columns).toHaveLength(4);
+      expect(result.columns[0].name).toBe('table_catalog');
+      expect(result.columns[1].name).toBe('table_schema');
+      expect(result.columns[2].name).toBe('table_name');
+      expect(result.columns[3].name).toBe('table_type');
+      
+      // Check data types
+      expect(result.columns[0].dataTypeOID).toBe(DATA_TYPES.NAME);
+      expect(result.columns[3].dataTypeOID).toBe(DATA_TYPES.TEXT);
+      
+      // Check that we have mock tables
+      expect(result.rowCount).toBeGreaterThan(0);
+      expect(result.rows[0]).toHaveLength(4);
+      
+      // Verify mock data structure
+      const firstRow = result.rows[0];
+      expect(firstRow[0]).toBe('postgres'); // table_catalog
+      expect(firstRow[1]).toBe('public');   // table_schema
+      expect(['users', 'posts']).toContain(firstRow[2]); // table_name
+      expect(firstRow[3]).toBe('BASE TABLE'); // table_type
+    });
+  });
+
+  describe('Information Schema Columns', () => {
+    test('should return correct column structure for information_schema.columns', () => {
+      const result = handleInformationSchemaColumns('', mockConnState);
+      
+      // Check column structure
+      expect(result.columns).toHaveLength(9);
+      expect(result.columns[0].name).toBe('table_catalog');
+      expect(result.columns[3].name).toBe('column_name');
+      expect(result.columns[7].name).toBe('data_type');
+      
+      // Check that we have columns from mock tables
+      expect(result.rowCount).toBeGreaterThan(0);
+      
+      // Verify we have columns from both tables
+      const columnNames = result.rows.map(row => row[3]); // column_name
+      expect(columnNames).toContain('id');
+      expect(columnNames).toContain('name');
+      expect(columnNames).toContain('email');
+    });
+
+    test('should include proper data types for columns', () => {
+      const result = handleInformationSchemaColumns('', mockConnState);
+      
+      // Find the 'id' column
+      const idColumn = result.rows.find(row => row[3] === 'id');
+      expect(idColumn).toBeDefined();
+      expect(idColumn[7]).toBe('integer'); // data_type
+      expect(idColumn[6]).toBe('NO');      // is_nullable
+      
+      // Find the 'name' column
+      const nameColumn = result.rows.find(row => row[3] === 'name');
+      expect(nameColumn).toBeDefined();
+      expect(nameColumn[7]).toBe('character varying'); // data_type
+      expect(nameColumn[6]).toBe('YES');                // is_nullable
+    });
+  });
+
+  describe('Information Schema Schemata', () => {
+    test('should return correct schema structure', () => {
+      const result = handleInformationSchemaSchemata('', mockConnState);
+      
+      // Check column structure
+      expect(result.columns).toHaveLength(3);
+      expect(result.columns[0].name).toBe('catalog_name');
+      expect(result.columns[1].name).toBe('schema_name');
+      expect(result.columns[2].name).toBe('schema_owner');
+      
+      // Check that we have the expected schemas
+      expect(result.rowCount).toBe(3);
+      const schemaNames = result.rows.map(row => row[1]);
+      expect(schemaNames).toContain('public');
+      expect(schemaNames).toContain('information_schema');
+      expect(schemaNames).toContain('pg_catalog');
+    });
+  });
+
+  describe('PostgreSQL Catalog Queries', () => {
+    test('should handle pg_catalog.pg_tables correctly', () => {
+      const result = handlePgTables('', mockConnState);
+      
+      // Check column structure matches PostgreSQL pg_tables
+      expect(result.columns).toHaveLength(8);
+      expect(result.columns[0].name).toBe('schemaname');
+      expect(result.columns[1].name).toBe('tablename');
+      expect(result.columns[4].name).toBe('hasindexes');
+      
+      // Check data types
+      expect(result.columns[4].dataTypeOID).toBe(DATA_TYPES.BOOL);
+      
+      // Verify we have tables
+      expect(result.rowCount).toBeGreaterThan(0);
+      const tableNames = result.rows.map(row => row[1]);
+      expect(tableNames).toContain('users');
+      expect(tableNames).toContain('posts');
+    });
+
+    test('should handle pg_catalog.pg_type correctly', () => {
+      const result = handlePgType('', mockConnState);
+      
+      // Check column structure
+      expect(result.columns).toHaveLength(5);
+      expect(result.columns[0].name).toBe('oid');
+      expect(result.columns[1].name).toBe('typname');
+      
+      // Check that we have common data types
+      expect(result.rowCount).toBeGreaterThan(0);
+      const typeNames = result.rows.map(row => row[1]);
+      expect(typeNames).toContain('bool');
+      expect(typeNames).toContain('int4');
+      expect(typeNames).toContain('text');
+      expect(typeNames).toContain('varchar');
+    });
+
+    test('should handle pg_catalog.pg_class correctly', () => {
+      const result = handlePgClass('', mockConnState);
+      
+      // Check column structure
+      expect(result.columns).toHaveLength(8);
+      expect(result.columns[0].name).toBe('oid');
+      expect(result.columns[1].name).toBe('relname');
+      expect(result.columns[3].name).toBe('relkind');
+      
+      // Verify we have relations (tables)
+      expect(result.rowCount).toBeGreaterThan(0);
+      const relationNames = result.rows.map(row => row[1]);
+      expect(relationNames).toContain('users');
+      expect(relationNames).toContain('posts');
+      
+      // Check that all relations are marked as tables
+      result.rows.forEach(row => {
+        expect(row[3]).toBe('r'); // relkind = 'r' for ordinary table
+      });
+    });
+  });
+
+  describe('Query Integration', () => {
+    test('should handle case-insensitive schema names', () => {
+      const lowerQuery = 'select * from information_schema.tables';
+      const upperQuery = 'SELECT * FROM INFORMATION_SCHEMA.TABLES';
+      
+      const lowerResult = handleIntrospectionQuery(lowerQuery, mockConnState);
+      const upperResult = handleIntrospectionQuery(upperQuery, mockConnState);
+      
+      expect(lowerResult.rowCount).toBe(upperResult.rowCount);
+      expect(lowerResult.columns).toEqual(upperResult.columns);
+    });
+
+    test('should route pg_catalog queries to correct handlers', () => {
+      const query = 'SELECT * FROM pg_catalog.pg_type WHERE typname = \'int4\'';
+      const result = handlePgCatalogQuery(query, mockConnState);
+      
+      expect(result.command).toBe('SELECT');
+      expect(result.rowCount).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/handlers/queryHandlers.js
+++ b/src/handlers/queryHandlers.js
@@ -16,6 +16,97 @@ const {
 } = require('../protocol/messageBuilders');
 
 /**
+ * Mock database schema for introspection queries
+ * This represents a realistic database structure that tools and ORMs can discover
+ */
+const MOCK_SCHEMA = {
+  // Database schemas (namespaces)
+  schemas: [
+    { schema_name: 'public' },
+    { schema_name: 'information_schema' },
+    { schema_name: 'pg_catalog' },
+  ],
+  
+  // Mock tables with realistic structure
+  tables: [
+    {
+      table_catalog: 'postgres',
+      table_schema: 'public',
+      table_name: 'users',
+      table_type: 'BASE TABLE',
+      columns: [
+        {
+          column_name: 'id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+          column_default: 'nextval(\'users_id_seq\'::regclass)',
+          ordinal_position: 1,
+        },
+        {
+          column_name: 'name',
+          data_type: 'character varying',
+          character_maximum_length: 255,
+          is_nullable: 'YES',
+          column_default: null,
+          ordinal_position: 2,
+        },
+        {
+          column_name: 'email',
+          data_type: 'character varying',
+          character_maximum_length: 255,
+          is_nullable: 'NO',
+          column_default: null,
+          ordinal_position: 3,
+        },
+        {
+          column_name: 'created_at',
+          data_type: 'timestamp with time zone',
+          is_nullable: 'NO',
+          column_default: 'CURRENT_TIMESTAMP',
+          ordinal_position: 4,
+        },
+      ],
+    },
+    {
+      table_catalog: 'postgres',
+      table_schema: 'public',
+      table_name: 'posts',
+      table_type: 'BASE TABLE',
+      columns: [
+        {
+          column_name: 'id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+          column_default: 'nextval(\'posts_id_seq\'::regclass)',
+          ordinal_position: 1,
+        },
+        {
+          column_name: 'title',
+          data_type: 'text',
+          is_nullable: 'NO',
+          column_default: null,
+          ordinal_position: 2,
+        },
+        {
+          column_name: 'content',
+          data_type: 'text',
+          is_nullable: 'YES',
+          column_default: null,
+          ordinal_position: 3,
+        },
+        {
+          column_name: 'user_id',
+          data_type: 'integer',
+          is_nullable: 'NO',
+          column_default: null,
+          ordinal_position: 4,
+        },
+      ],
+    },
+  ],
+};
+
+/**
  * Query result structure
  * @typedef {Object} QueryResult
  * @property {Array} columns - Column descriptors for RowDescription
@@ -120,7 +211,11 @@ function processQuery(query, connState) {
 
   try {
     // Route to appropriate handler based on query type
-    if (normalizedQuery.startsWith('SELECT')) {
+    
+    // Check for database introspection queries first (before general SELECT)
+    if (normalizedQuery.includes('INFORMATION_SCHEMA.') || normalizedQuery.includes('PG_CATALOG.')) {
+      return handleIntrospectionQuery(normalizedQuery, connState);
+    } else if (normalizedQuery.startsWith('SELECT')) {
       return handleSelectQuery(normalizedQuery, connState);
     } else if (normalizedQuery.startsWith('SHOW')) {
       return handleShowQuery(normalizedQuery, connState);
@@ -566,6 +661,279 @@ function getQueryType(query) {
   return firstWord || 'UNKNOWN';
 }
 
+/**
+ * Handles database introspection queries (information_schema and pg_catalog)
+ * @param {string} query - The introspection query
+ * @param {ConnectionState} connState - Connection state object
+ * @returns {QueryResult} Query result
+ */
+function handleIntrospectionQuery(query, connState) {
+  const upperQuery = query.toUpperCase();
+  
+  // Handle information_schema queries
+  if (upperQuery.includes('INFORMATION_SCHEMA.TABLES')) {
+    return handleInformationSchemaTables(query, connState);
+  } else if (upperQuery.includes('INFORMATION_SCHEMA.COLUMNS')) {
+    return handleInformationSchemaColumns(query, connState);
+  } else if (upperQuery.includes('INFORMATION_SCHEMA.SCHEMATA')) {
+    return handleInformationSchemaSchemata(query, connState);
+  }
+  
+  // Handle pg_catalog queries (we'll implement these in step 4)
+  else if (upperQuery.includes('PG_CATALOG.')) {
+    return handlePgCatalogQuery(query, connState);
+  }
+  
+  // Fallback for unknown introspection queries
+  return {
+    columns: [
+      {
+        name: 'note',
+        dataTypeOID: DATA_TYPES.TEXT,
+        dataTypeSize: -1,
+      },
+    ],
+    rows: [['Introspection query not yet implemented: ' + query.substring(0, 100)]],
+    command: 'SELECT',
+    rowCount: 1,
+  };
+}
+
+/**
+ * Handles information_schema.tables queries
+ * Returns list of tables in the database
+ */
+function handleInformationSchemaTables(_query, _connState) {
+  // Build the standard information_schema.tables columns
+  const columns = [
+    { name: 'table_catalog', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'table_schema', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'table_name', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'table_type', dataTypeOID: DATA_TYPES.TEXT, dataTypeSize: -1 },
+  ];
+
+  // Convert our mock schema tables to information_schema format
+  const rows = MOCK_SCHEMA.tables.map(table => [
+    table.table_catalog,
+    table.table_schema,
+    table.table_name,
+    table.table_type,
+  ]);
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
+/**
+ * Handles information_schema.columns queries
+ * Returns list of columns for tables
+ */
+function handleInformationSchemaColumns(_query, _connState) {
+  const columns = [
+    { name: 'table_catalog', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'table_schema', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'table_name', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'column_name', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'ordinal_position', dataTypeOID: DATA_TYPES.INT4, dataTypeSize: 4 },
+    { name: 'column_default', dataTypeOID: DATA_TYPES.TEXT, dataTypeSize: -1 },
+    { name: 'is_nullable', dataTypeOID: DATA_TYPES.TEXT, dataTypeSize: -1 },
+    { name: 'data_type', dataTypeOID: DATA_TYPES.TEXT, dataTypeSize: -1 },
+    { name: 'character_maximum_length', dataTypeOID: DATA_TYPES.INT4, dataTypeSize: 4 },
+  ];
+
+  // Build rows from all columns in all tables
+  const rows = [];
+  MOCK_SCHEMA.tables.forEach(table => {
+    table.columns.forEach(column => {
+      rows.push([
+        table.table_catalog,
+        table.table_schema,
+        table.table_name,
+        column.column_name,
+        column.ordinal_position.toString(),
+        column.column_default,
+        column.is_nullable,
+        column.data_type,
+        column.character_maximum_length ? column.character_maximum_length.toString() : null,
+      ]);
+    });
+  });
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
+/**
+ * Handles information_schema.schemata queries
+ * Returns list of database schemas (namespaces)
+ */
+function handleInformationSchemaSchemata(_query, _connState) {
+  const columns = [
+    { name: 'catalog_name', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'schema_name', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'schema_owner', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+  ];
+
+  const rows = MOCK_SCHEMA.schemas.map(schema => [
+    'postgres', // catalog_name
+    schema.schema_name,
+    'postgres', // schema_owner
+  ]);
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
+/**
+ * Handles pg_catalog queries (PostgreSQL system catalogs)
+ * @param {string} query - The pg_catalog query
+ * @param {ConnectionState} connState - Connection state object
+ * @returns {QueryResult} Query result
+ */
+function handlePgCatalogQuery(query, connState) {
+  const upperQuery = query.toUpperCase();
+  
+  if (upperQuery.includes('PG_CATALOG.PG_TABLES')) {
+    return handlePgTables(query, connState);
+  } else if (upperQuery.includes('PG_CATALOG.PG_TYPE')) {
+    return handlePgType(query, connState);
+  } else if (upperQuery.includes('PG_CATALOG.PG_CLASS')) {
+    return handlePgClass(query, connState);
+  }
+  
+  // Fallback for unknown pg_catalog queries
+  return {
+    columns: [
+      {
+        name: 'note',
+        dataTypeOID: DATA_TYPES.TEXT,
+        dataTypeSize: -1,
+      },
+    ],
+    rows: [['pg_catalog query not yet implemented: ' + query.substring(0, 100)]],
+    command: 'SELECT',
+    rowCount: 1,
+  };
+}
+
+/**
+ * Handles pg_catalog.pg_tables queries
+ * PostgreSQL-specific table information
+ */
+function handlePgTables(_query, _connState) {
+  const columns = [
+    { name: 'schemaname', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'tablename', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'tableowner', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'tablespace', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'hasindexes', dataTypeOID: DATA_TYPES.BOOL, dataTypeSize: 1 },
+    { name: 'hasrules', dataTypeOID: DATA_TYPES.BOOL, dataTypeSize: 1 },
+    { name: 'hastriggers', dataTypeOID: DATA_TYPES.BOOL, dataTypeSize: 1 },
+    { name: 'rowsecurity', dataTypeOID: DATA_TYPES.BOOL, dataTypeSize: 1 },
+  ];
+
+  const rows = MOCK_SCHEMA.tables
+    .filter(table => table.table_type === 'BASE TABLE')
+    .map(table => [
+      table.table_schema,    // schemaname
+      table.table_name,      // tablename
+      'postgres',            // tableowner
+      null,                  // tablespace
+      'true',                // hasindexes
+      'false',               // hasrules
+      'false',               // hastriggers
+      'false',               // rowsecurity
+    ]);
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
+/**
+ * Handles pg_catalog.pg_type queries
+ * PostgreSQL data type information
+ */
+function handlePgType(_query, _connState) {
+  const columns = [
+    { name: 'oid', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'typname', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'typnamespace', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'typlen', dataTypeOID: DATA_TYPES.INT2, dataTypeSize: 2 },
+    { name: 'typtype', dataTypeOID: DATA_TYPES.CHAR, dataTypeSize: 1 },
+  ];
+
+  // Common PostgreSQL data types
+  const rows = [
+    [DATA_TYPES.BOOL.toString(), 'bool', '11', '1', 'b'],
+    [DATA_TYPES.INT2.toString(), 'int2', '11', '2', 'b'],
+    [DATA_TYPES.INT4.toString(), 'int4', '11', '4', 'b'],
+    [DATA_TYPES.INT8.toString(), 'int8', '11', '8', 'b'],
+    [DATA_TYPES.TEXT.toString(), 'text', '11', '-1', 'b'],
+    [DATA_TYPES.VARCHAR.toString(), 'varchar', '11', '-1', 'b'],
+    [DATA_TYPES.TIMESTAMP.toString(), 'timestamp', '11', '8', 'b'],
+    [DATA_TYPES.TIMESTAMPTZ.toString(), 'timestamptz', '11', '8', 'b'],
+  ];
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
+/**
+ * Handles pg_catalog.pg_class queries
+ * PostgreSQL relation (table/index/sequence) information
+ */
+function handlePgClass(_query, _connState) {
+  const columns = [
+    { name: 'oid', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'relname', dataTypeOID: DATA_TYPES.NAME, dataTypeSize: 64 },
+    { name: 'relnamespace', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'relkind', dataTypeOID: DATA_TYPES.CHAR, dataTypeSize: 1 },
+    { name: 'relowner', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'reltablespace', dataTypeOID: DATA_TYPES.OID, dataTypeSize: 4 },
+    { name: 'reltuples', dataTypeOID: DATA_TYPES.FLOAT4, dataTypeSize: 4 },
+    { name: 'relpages', dataTypeOID: DATA_TYPES.INT4, dataTypeSize: 4 },
+  ];
+
+  // Mock relations (tables) from our schema
+  const rows = MOCK_SCHEMA.tables.map((table, index) => [
+    (16384 + index).toString(),  // oid (fake but realistic)
+    table.table_name,            // relname
+    '2200',                      // relnamespace (public schema)
+    'r',                         // relkind ('r' = ordinary table)
+    '10',                        // relowner (postgres user)
+    '0',                         // reltablespace (default)
+    '100.0',                     // reltuples (estimated row count)
+    '10',                        // relpages (estimated page count)
+  ]);
+
+  return {
+    columns,
+    rows,
+    command: 'SELECT',
+    rowCount: rows.length,
+  };
+}
+
 module.exports = {
   executeQuery,
   executeQueryString,
@@ -580,6 +948,14 @@ module.exports = {
   handleCreateQuery,
   handleDropQuery,
   handleUnknownQuery,
+  handleIntrospectionQuery,
+  handleInformationSchemaTables,
+  handleInformationSchemaColumns,
+  handleInformationSchemaSchemata,
+  handlePgCatalogQuery,
+  handlePgTables,
+  handlePgType,
+  handlePgClass,
   updateTransactionStatus,
   validateQuery,
   getQueryType,


### PR DESCRIPTION
# Pull Request Description

## Changes Proposed

This PR implements comprehensive database introspection support for the pg-wire-mock server, addressing issue #64. The implementation adds support for standard PostgreSQL introspection queries that ORMs rely on for schema discovery.

**Key Changes:**
- Added support for `information_schema` queries (tables, columns, schemata)
- Added support for `pg_catalog` queries (pg_tables, pg_type, pg_class)
- Created a realistic mock schema with `users` and `posts` tables
- Enhanced query routing to detect and handle introspection queries
- Added comprehensive test coverage with 13 new unit tests

**Problem Solved:**
ORMs use database introspection queries to discover schema information. Previously, these tools would fail when connecting to pg-wire-mock because it couldn't respond to standard PostgreSQL introspection queries.

## Related Issues

Fixes #64

## Checklist

- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated
- [x] All tests pass locally
- [x] Documentation has been updated
- [x] The code follows project style guidelines
- [x] No new warnings are generated

## Screenshots (if appropriate)
**Testing:**
<img width="1903" height="643" alt="pr2 1" src="https://github.com/user-attachments/assets/e7c29ef3-a71f-40b3-913a-70a5cd38d7ad" />
<img width="1093" height="812" alt="pr2 2" src="https://github.com/user-attachments/assets/f356a9e7-9323-4360-83e5-08e31bd27e99" />


## Additional Notes

**Files Modified:**
- `src/handlers/queryHandlers.js` - Main implementation
- `__tests__/introspection.test.js` - New test suite

